### PR TITLE
[ROS-O] support ImageMagick 6 and 7 (#31 for noetic)

### DIFF
--- a/sr_movements/src/movement_from_image.cpp
+++ b/sr_movements/src/movement_from_image.cpp
@@ -50,16 +50,14 @@ namespace shadowrobot
 
   void MovementFromImage::generate_movement_()
   {
-    const Magick::PixelPacket* pixel_cache = image_->getConstPixels(0, 0, nb_cols_, nb_rows_);
+    Magick::Color white("white");
 
     for (ssize_t col = 0; col < nb_cols_; ++col)
     {
       bool no_pixel = true;
       for (ssize_t row = 0; row < nb_rows_; ++row)
       {
-        const Magick::PixelPacket* tmp_pixel = pixel_cache + row * nb_cols_ + col;
-        if (tmp_pixel->red != 0xFFFF && tmp_pixel->green != 0xFFFF
-           && tmp_pixel->blue != 0xFFFF)
+        if (image_->pixelColor(row, col) != white)
         {
           no_pixel = false;
           steps.push_back(1.0 - static_cast<double>(row) / static_cast<double>(nb_rows_));

--- a/sr_movements/src/movement_from_image.cpp
+++ b/sr_movements/src/movement_from_image.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2019 Shadow Robot Company Ltd.
+* Copyright 2019, 2022 Shadow Robot Company Ltd.
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free


### PR DESCRIPTION
Port https://github.com/shadow-robot/sr_tools/pull/31 to noetic.
Apparently noetic-devel was split off before #31 was merged, so the same issue comes up again.
This is required to compile sr_movements in RoboStack (e.g., on Ubuntu 22.04).

@biofotis 