### PR TITLE
[ROS-O] work around include issue with Magick++

### DIFF
--- a/sr_movements/include/sr_movements/movement_from_image.hpp
+++ b/sr_movements/include/sr_movements/movement_from_image.hpp
@@ -29,9 +29,9 @@
 #define _MOVEMENT_FROM_IMAGE_HPP_
 
 #include <string>
+#include <boost/smart_ptr.hpp>
 #include <Magick++.h>
 #include "sr_movements/partial_movement.hpp"
-#include <boost/smart_ptr.hpp>
 
 namespace shadowrobot
 {


### PR DESCRIPTION
On Debian bookworm I see this error with the current code:

```
In file included from /usr/include/boost/assert.hpp:58,
                 from /usr/include/boost/thread/pthread/mutex.hpp:22,
                 from /usr/include/boost/thread/mutex.hpp:16,
                 from include/ros/publisher.h:36,
                 from include/ros/node_handle.h:32,
                 from include/ros/ros.h:45,
                 from sr_tools/sr_movements/src/movement_from_image.cpp:31:
/usr/include/boost/thread/detail/platform_time.hpp: In static member function ‘static boost::detail::real_platform_timepoint boost::detail::real_platform_clock ::now()’:
/usr/include/boost/thread/detail/platform_time.hpp:311:11: error: ‘__assert_fail’ was not declared in this scope; did you mean ‘MagickCore::__assert_fail’?
  311 |           BOOST_ASSERT(0 && "Boost::Thread - clock_gettime(CLOCK_REALTIME) Internal Error");
      |           ^~~~~~~~~~~~
```

which is due to (Debian's?) Magick++ 6 including the assert header in a namespace by accident. While this is clearly a bug upstream as includes should be agnostic to order, there is clearly no harm in changing the order here for a faster fix.

## Tests

- [x] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
